### PR TITLE
Export outputdir as environment var during build

### DIFF
--- a/src/document-provider.ts
+++ b/src/document-provider.ts
@@ -165,7 +165,8 @@ export default class LatexDocumentProvider implements vscode.TextDocumentContent
     this.output.appendLine(command);
 
     return new Promise((resolve, reject) => {
-      cp.exec(command, { cwd: dirname(path) }, (err, stdout, stderr) => {
+      let env = Object.assign({}, process.env, { "OUTPUTDIR": arg(dir) });
+      cp.exec(command, { cwd: dirname(path), env: env }, (err, stdout, stderr) => {
         this.diagnostics.clear();
         this.output.append(stdout);
         this.output.append(stderr);


### PR DESCRIPTION
This should be a workaround for #8 and similar issues, where the output directory path is needed in the source code during compilation.

You can now use minted like this using the `catchfile` package:

```latex
\documentclass{article}

\usepackage{catchfile}
\CatchFileEdef{\OUTPUTDIR}{"|kpsewhich --var-value OUTPUTDIR"}{}

\usepackage[outputdir=\OUTPUTDIR]{minted}

\begin{document}

\begin{minted}{lisp}
(defun foo-bar (bar faz)
  (if faz
      bar
      (mapcar #'foobar bar)))
\end{minted}
\end{document}

```